### PR TITLE
Update cover image link for Readme file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cybersecurity handbook
 
-![Cover image](public/cover.jpg)
+![Cover image](static/img/cover.jpg)
 _Image from [needpix.com](https://www.needpix.com/photo/download/963169/hacker-cyber-crime-banner-header-internet-computer-security-cyber-technology)_
 
 Empowering you to stay safe in the digital world with One Beyond&#39;s Cybersecurity Handbook.


### PR DESCRIPTION
## Description
Cover image url in readme file was broken.

## Related Issue
close #68

## Motivation and Context
To be available to see the readme file without any errors.

## How Has This Been Tested?
Tested in fork readme.

## Screenshots (if appropriate):
Current: 
<img width="931" alt="image" src="https://github.com/onebeyond/cybersecurity-handbook/assets/12125288/c9df6348-83cc-4f89-a07f-3cb7cd1133a6">


Updated: 
<img width="954" alt="image" src="https://github.com/onebeyond/cybersecurity-handbook/assets/12125288/f9c7f492-faa1-4458-95da-ad7748741d0b">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
